### PR TITLE
Feature: sync current time and duration time

### DIFF
--- a/src/Timeline/NumberInput.spec.tsx
+++ b/src/Timeline/NumberInput.spec.tsx
@@ -336,8 +336,11 @@ describe("NumberInput requirements", () => {
       await userEvent.click(input);
       await userEvent.clear(input);
       await userEvent.type(input, "00100");
+      expect(input).not.toHaveAttribute("data-invalid"); // Currently count as valid because this can represent a number
+
       await userEvent.tab();
       expect(input.value).toBe("100");
+      expect(input).not.toHaveAttribute("data-invalid");
     });
 
     test("Negative values are automatically adjusted to the minimum allowed value (with direct pasting)", async () => {
@@ -351,9 +354,11 @@ describe("NumberInput requirements", () => {
       await userEvent.click(input);
       await userEvent.paste("-5");
       expect(input.value).toBe("-5");
+      expect(input).toHaveAttribute("data-invalid", "true");
 
       await userEvent.tab();
       expect(input.value).toBe("0");
+      expect(input).not.toHaveAttribute("data-invalid");
     });
 
     test("Negative values are automatically adjusted to the minimum allowed value (with typing)", async () => {
@@ -368,9 +373,11 @@ describe("NumberInput requirements", () => {
       await userEvent.clear(input);
       await userEvent.type(input, "-5");
       expect(input.value).toBe("-5");
+      expect(input).toHaveAttribute("data-invalid", "true");
 
       await userEvent.tab();
       expect(input.value).toBe("0");
+      expect(input).not.toHaveAttribute("data-invalid");
     });
 
     test("Decimal values are automatically rounded to the nearest integer", async () => {
@@ -384,8 +391,11 @@ describe("NumberInput requirements", () => {
       await userEvent.click(input);
       await userEvent.clear(input);
       await userEvent.type(input, "15.6");
+      expect(input).toHaveAttribute("data-invalid", "true");
+
       await userEvent.tab();
       expect(input.value).toBe("20");
+      expect(input).not.toHaveAttribute("data-invalid");
     });
 
     test("Invalid inputs (non-numeric) revert to the previous valid value", async () => {
@@ -399,25 +409,31 @@ describe("NumberInput requirements", () => {
       await userEvent.click(input);
       await userEvent.clear(input);
       await userEvent.type(input, "abc");
+      expect(input).toHaveAttribute("data-invalid", "true");
+
       await userEvent.tab();
       expect(input.value).toBe("0");
+      expect(input).not.toHaveAttribute("data-invalid");
     });
   });
 
   describe("validateNumber edge cases", () => {
     test("Infinity is adjusted to the maximum allowed value", async () => {
-      const value = validateNumber(Infinity, config);
-      expect(value).toBe(config.max);
+      const { result, hasError } = validateNumber(Infinity, config);
+      expect(result).toBe(config.max);
+      expect(hasError).toBe(true);
     });
 
     test("-Infinity is adjusted to the minimum allowed value", async () => {
-      const value = validateNumber(-Infinity, config);
-      expect(value).toBe(config.min);
+      const { result, hasError } = validateNumber(-Infinity, config);
+      expect(result).toBe(config.min);
+      expect(hasError).toBe(true);
     });
 
     test("NaN is adjusted to the minimum allowed value", async () => {
-      const value = validateNumber(NaN, config);
-      expect(value).toBe(config.min);
+      const { result, hasError } = validateNumber(NaN, config);
+      expect(result).toBe(config.min);
+      expect(hasError).toBe(true);
     });
   });
 });

--- a/src/Timeline/NumberInput.spec.tsx
+++ b/src/Timeline/NumberInput.spec.tsx
@@ -1,12 +1,7 @@
 import { fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React, { createContext, useContext, useState } from "react";
-import {
-  NumberConfig,
-  NumberInput,
-  NumberInputProps,
-  validateNumber,
-} from "./NumberInput";
+import { NumberInput, NumberInputProps, validateNumber } from "./NumberInput";
 
 describe("NumberInput requirements", () => {
   type NumberContextValue = {
@@ -65,7 +60,10 @@ describe("NumberInput requirements", () => {
     min: 0,
     max: 100,
   };
-  let validatorSpy: jest.Mock<number, [number, NumberConfig]>;
+  let validatorSpy: jest.Mock<
+    ReturnType<NumberInputProps["validator"]>,
+    Parameters<NumberInputProps["validator"]>
+  >;
   let onChangeSpy: jest.Mock<void, [number]>;
 
   // WORKAROUND: the correct behavior is not simulated by JSDOM

--- a/src/Timeline/PlayControls.spec.tsx
+++ b/src/Timeline/PlayControls.spec.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PropsWithChildren, useState } from "react";
+import { PlayControls } from "./PlayControls";
+import { TimelineContext } from "./TimelineContext";
+
+describe("PlayControls requirements", () => {
+  const TimelineProvider = ({
+    initialTime,
+    children,
+  }: PropsWithChildren<{ initialTime: number }>) => {
+    const [time, setTime] = useState(initialTime);
+    return (
+      <TimelineContext.Provider value={{ time, setTime }}>
+        {children}
+      </TimelineContext.Provider>
+    );
+  };
+
+  test("Current Time is always between 0ms and the Duration", async () => {
+    render(
+      <TimelineProvider initialTime={0}>
+        <PlayControls />
+      </TimelineProvider>
+    );
+    const currentInput = screen.getByTestId(
+      "current-time-input"
+    ) as HTMLInputElement;
+
+    await userEvent.clear(currentInput);
+    await userEvent.type(currentInput, "-50");
+    await userEvent.tab();
+    expect(parseInt(currentInput.value, 10)).toBeGreaterThanOrEqual(0);
+
+    await userEvent.clear(currentInput);
+    await userEvent.type(currentInput, "7000");
+    await userEvent.tab();
+    expect(parseInt(currentInput.value, 10)).toBeLessThanOrEqual(6000);
+  });
+
+  test("Current Time adjusts if it exceeds the newly set Duration", async () => {
+    render(
+      <TimelineProvider initialTime={5000}>
+        <PlayControls />
+      </TimelineProvider>
+    );
+
+    const currentInput = screen.getByTestId(
+      "current-time-input"
+    ) as HTMLInputElement;
+    const durationInput = screen.getByTestId(
+      "duration-input"
+    ) as HTMLInputElement;
+
+    await userEvent.clear(durationInput);
+    await userEvent.type(durationInput, "4000");
+    await userEvent.tab();
+    expect(parseInt(currentInput.value, 10)).toBe(4000);
+  });
+
+  test("Duration is always between 100ms and 6000ms", async () => {
+    render(
+      <TimelineProvider initialTime={0}>
+        <PlayControls />
+      </TimelineProvider>
+    );
+    const durationInput = screen.getByTestId(
+      "duration-input"
+    ) as HTMLInputElement;
+
+    await userEvent.clear(durationInput);
+    await userEvent.type(durationInput, "50");
+    await userEvent.tab();
+    expect(parseInt(durationInput.value, 10)).toBeGreaterThanOrEqual(100);
+
+    await userEvent.clear(durationInput);
+    await userEvent.type(durationInput, "7000");
+    await userEvent.tab();
+    expect(parseInt(durationInput.value, 10)).toBeLessThanOrEqual(6000);
+  });
+
+  test("Current Time and Duration are always multiples of 10ms and positive integers", async () => {
+    render(
+      <TimelineProvider initialTime={0}>
+        <PlayControls />
+      </TimelineProvider>
+    );
+    const currentInput = screen.getByTestId(
+      "current-time-input"
+    ) as HTMLInputElement;
+    const durationInput = screen.getByTestId(
+      "duration-input"
+    ) as HTMLInputElement;
+
+    const fillThis = async (input: HTMLInputElement, value: string) => {
+      await userEvent.clear(input);
+      await userEvent.type(input, value);
+      await userEvent.tab();
+    };
+
+    const expectThese = (value: number) => {
+      expect(value % 10).toBe(0);
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(0);
+    };
+
+    await fillThis(currentInput, "123");
+    expectThese(parseInt(currentInput.value, 10));
+
+    await fillThis(durationInput, "157");
+    expectThese(parseInt(currentInput.value, 10));
+
+    await fillThis(currentInput, "-123");
+    expectThese(parseInt(currentInput.value, 10));
+
+    await fillThis(durationInput, "-157");
+    expectThese(parseInt(currentInput.value, 10));
+  });
+});

--- a/src/Timeline/PlayControls.tsx
+++ b/src/Timeline/PlayControls.tsx
@@ -1,4 +1,4 @@
-import { memo, useContext } from "react";
+import { memo, useContext, useState } from "react";
 import { NumberInput, validateNumber } from "./NumberInput";
 import { RenderTracker } from "./RenderTracker";
 import { TimelineContext } from "./TimelineContext";
@@ -21,8 +21,9 @@ const durationTimeConfig = {
 };
 
 export const PlayControls = () => {
-  const { time: globalTime, setTime: setGlobalTime } =
+  const { time: currentTime, setTime: setCurrentTime } =
     useContext(TimelineContext);
+  const [durationTime, setDurationTime] = useState(durationTimeConfig.max);
 
   return (
     <>
@@ -35,28 +36,29 @@ export const PlayControls = () => {
         <fieldset className="flex gap-1">
           Current
           <NumberInput
-            value={globalTime}
-            onChange={setGlobalTime}
+            value={currentTime}
+            onChange={setCurrentTime}
             data-testid="current-time-input"
             validator={validateNumber}
             config={{
               step: currentTimeConfig.step,
               min: currentTimeConfig.min,
-              max: 2000, // TODO should be the current duration and defined in a Context
+              max: durationTime,
             }}
           />
         </fieldset>
         -
         <fieldset className="flex gap-1">
-          {/* TODO create a DurationTimeInput */}
-          <input
-            className="bg-gray-700 px-1 rounded"
-            type="number"
+          <NumberInput
+            value={durationTime}
+            onChange={setDurationTime}
             data-testid="duration-input"
-            min={durationTimeConfig.min}
-            max={durationTimeConfig.max}
-            step={durationTimeConfig.step}
-            defaultValue={durationTimeConfig.max}
+            validator={validateNumber}
+            config={{
+              step: durationTimeConfig.step,
+              min: durationTimeConfig.min,
+              max: durationTimeConfig.max,
+            }}
           />
           Duration
         </fieldset>

--- a/src/Timeline/PlayControls.tsx
+++ b/src/Timeline/PlayControls.tsx
@@ -1,29 +1,41 @@
-import { memo, useContext, useState } from "react";
+import { memo, useCallback, useContext, useMemo, useState } from "react";
 import { NumberInput, validateNumber } from "./NumberInput";
 import { RenderTracker } from "./RenderTracker";
 import { TimelineContext } from "./TimelineContext";
 
-const currentTimeConfig = {
-  /**
-   * In unit of Milliseconds
-   */
-  step: 10,
-  min: 0,
-};
-
-const durationTimeConfig = {
-  /**
-   * In unit of Milliseconds
-   */
-  step: 10,
-  min: 100,
-  max: 6000,
-};
-
 export const PlayControls = () => {
+  const durationTimeConfig = useMemo(
+    () => ({
+      /**
+       * In unit of Milliseconds
+       */
+      step: 10,
+      min: 100,
+      max: 6000,
+    }),
+    []
+  );
+  const [durationTime, setDurationTime] = useState(durationTimeConfig.max);
+  const currentTimeConfig = useMemo(
+    () => ({
+      /**
+       * In unit of Milliseconds
+       */
+      step: 10,
+      min: 0,
+      max: durationTime,
+    }),
+    [durationTime]
+  );
   const { time: currentTime, setTime: setCurrentTime } =
     useContext(TimelineContext);
-  const [durationTime, setDurationTime] = useState(durationTimeConfig.max);
+  const setDurationTimeAndCapCurrentTime = useCallback(
+    (durationTimeValue: number) => {
+      setDurationTime(durationTimeValue);
+      setCurrentTime(Math.min(currentTime, durationTimeValue));
+    },
+    [currentTime]
+  );
 
   return (
     <>
@@ -40,18 +52,14 @@ export const PlayControls = () => {
             onChange={setCurrentTime}
             data-testid="current-time-input"
             validator={validateNumber}
-            config={{
-              step: currentTimeConfig.step,
-              min: currentTimeConfig.min,
-              max: durationTime,
-            }}
+            config={currentTimeConfig}
           />
         </fieldset>
         -
         <fieldset className="flex gap-1">
           <NumberInput
             value={durationTime}
-            onChange={setDurationTime}
+            onChange={setDurationTimeAndCapCurrentTime}
             data-testid="duration-input"
             validator={validateNumber}
             config={{


### PR DESCRIPTION
## Summary

Implement requirements in `2. Play Controls Behavior`.

- [x] Current Time is always between `0ms` and the Duration
- [x] Current Time adjusts if it exceeds the newly set Duration
- [x] Duration is always between `100ms` and `6000ms`
- [x] Current Time and Duration are always multiples of `10ms`
- [x] Current Time and Duration are always positive integers
- [x] Playhead position updates only after specific actions on Current Time input (losing focus, pressing Enter, using arrow keys, or clicking up/down buttons)

## Todo
1. Show `0` (the minimum allowed value) when pressing non numeric keys (e.g. A, B) - Currently it stays as empty when pressing these keys, but the final value is correctly set to `0`.