### PR TITLE
Feature: extend ruler component

### DIFF
--- a/src/Timeline/NumberInput.tsx
+++ b/src/Timeline/NumberInput.tsx
@@ -82,7 +82,7 @@ export function NumberInput({
       onChange(validatedValue);
       setLocalValue(validatedValue.toString());
     },
-    [onChange]
+    [config, onChange]
   );
 
   const handleChange = useCallback(

--- a/src/Timeline/NumberInput.tsx
+++ b/src/Timeline/NumberInput.tsx
@@ -108,8 +108,9 @@ export function NumberInput({
 
   const handleFocus = useCallback(() => {
     setIsEditing(true);
+    setLocalValue(valueString);
     selectInputText();
-  }, [selectInputText]);
+  }, [valueString, selectInputText]);
 
   const handleBlur = () => {
     if (blurTriggerKey.current === "Escape") {

--- a/src/Timeline/PlayControls.spec.tsx
+++ b/src/Timeline/PlayControls.spec.tsx
@@ -43,16 +43,24 @@ describe("PlayControls requirements", () => {
     const currentInput = screen.getByTestId(
       "current-time-input"
     ) as HTMLInputElement;
+    const durationInput = screen.getByTestId(
+      "duration-input"
+    ) as HTMLInputElement;
+    const durationTime = parseInt(durationInput.value);
+    expect(parseInt(currentInput.value, 10)).toBeGreaterThanOrEqual(0);
+    expect(parseInt(currentInput.value, 10)).toBeLessThanOrEqual(durationTime);
 
     await userEvent.clear(currentInput);
     await userEvent.type(currentInput, "-50");
     await userEvent.tab();
     expect(parseInt(currentInput.value, 10)).toBeGreaterThanOrEqual(0);
+    expect(parseInt(currentInput.value, 10)).toBeLessThanOrEqual(durationTime);
 
     await userEvent.clear(currentInput);
     await userEvent.type(currentInput, "7000");
     await userEvent.tab();
-    expect(parseInt(currentInput.value, 10)).toBeLessThanOrEqual(6000);
+    expect(parseInt(currentInput.value, 10)).toBeGreaterThanOrEqual(0);
+    expect(parseInt(currentInput.value, 10)).toBeLessThanOrEqual(durationTime);
   });
 
   test("Current Time adjusts if it exceeds the newly set Duration", async () => {
@@ -84,15 +92,19 @@ describe("PlayControls requirements", () => {
     const durationInput = screen.getByTestId(
       "duration-input"
     ) as HTMLInputElement;
+    expect(parseInt(durationInput.value, 10)).toBeGreaterThanOrEqual(100);
+    expect(parseInt(durationInput.value, 10)).toBeLessThanOrEqual(6000);
 
     await userEvent.clear(durationInput);
     await userEvent.type(durationInput, "50");
     await userEvent.tab();
     expect(parseInt(durationInput.value, 10)).toBeGreaterThanOrEqual(100);
+    expect(parseInt(durationInput.value, 10)).toBeLessThanOrEqual(6000);
 
     await userEvent.clear(durationInput);
     await userEvent.type(durationInput, "7000");
     await userEvent.tab();
+    expect(parseInt(durationInput.value, 10)).toBeGreaterThanOrEqual(100);
     expect(parseInt(durationInput.value, 10)).toBeLessThanOrEqual(6000);
   });
 

--- a/src/Timeline/PlayControls.spec.tsx
+++ b/src/Timeline/PlayControls.spec.tsx
@@ -6,12 +6,29 @@ import { TimelineContext } from "./TimelineContext";
 
 describe("PlayControls requirements", () => {
   const TimelineProvider = ({
-    initialTime,
+    initialCurrentTime,
+    initialDurationTime,
     children,
-  }: PropsWithChildren<{ initialTime: number }>) => {
-    const [time, setTime] = useState(initialTime);
+  }: PropsWithChildren<{
+    initialCurrentTime: number;
+    initialDurationTime: number;
+  }>) => {
+    const [currentTime, setCurrentTime] = useState(initialCurrentTime);
+    const [durationTime, setDurationTime] = useState(initialDurationTime);
+    const currentTimeConfig = { step: 10, min: 0, max: 6000 };
+    const durationTimeConfig = { step: 10, min: 100, max: 6000 };
     return (
-      <TimelineContext.Provider value={{ time, setTime }}>
+      <TimelineContext.Provider
+        value={{
+          currentTime,
+          setCurrentTime,
+          currentTimeConfig,
+          setCurrentTimeConfig: () => {},
+          durationTime,
+          setDurationTime,
+          durationTimeConfig,
+        }}
+      >
         {children}
       </TimelineContext.Provider>
     );
@@ -19,7 +36,7 @@ describe("PlayControls requirements", () => {
 
   test("Current Time is always between 0ms and the Duration", async () => {
     render(
-      <TimelineProvider initialTime={0}>
+      <TimelineProvider initialCurrentTime={0} initialDurationTime={6000}>
         <PlayControls />
       </TimelineProvider>
     );
@@ -40,7 +57,7 @@ describe("PlayControls requirements", () => {
 
   test("Current Time adjusts if it exceeds the newly set Duration", async () => {
     render(
-      <TimelineProvider initialTime={5000}>
+      <TimelineProvider initialCurrentTime={5000} initialDurationTime={6000}>
         <PlayControls />
       </TimelineProvider>
     );
@@ -60,7 +77,7 @@ describe("PlayControls requirements", () => {
 
   test("Duration is always between 100ms and 6000ms", async () => {
     render(
-      <TimelineProvider initialTime={0}>
+      <TimelineProvider initialCurrentTime={0} initialDurationTime={6000}>
         <PlayControls />
       </TimelineProvider>
     );
@@ -81,7 +98,7 @@ describe("PlayControls requirements", () => {
 
   test("Current Time and Duration are always multiples of 10ms and positive integers", async () => {
     render(
-      <TimelineProvider initialTime={0}>
+      <TimelineProvider initialCurrentTime={0} initialDurationTime={6000}>
         <PlayControls />
       </TimelineProvider>
     );

--- a/src/Timeline/PlayControls.tsx
+++ b/src/Timeline/PlayControls.tsx
@@ -1,41 +1,17 @@
-import { memo, useCallback, useContext, useMemo, useState } from "react";
+import { memo } from "react";
 import { NumberInput, validateNumber } from "./NumberInput";
 import { RenderTracker } from "./RenderTracker";
-import { TimelineContext } from "./TimelineContext";
+import { useTime } from "./useTime";
 
 export const PlayControls = () => {
-  const durationTimeConfig = useMemo(
-    () => ({
-      /**
-       * In unit of Milliseconds
-       */
-      step: 10,
-      min: 100,
-      max: 6000,
-    }),
-    []
-  );
-  const [durationTime, setDurationTime] = useState(durationTimeConfig.max);
-  const currentTimeConfig = useMemo(
-    () => ({
-      /**
-       * In unit of Milliseconds
-       */
-      step: 10,
-      min: 0,
-      max: durationTime,
-    }),
-    [durationTime]
-  );
-  const { time: currentTime, setTime: setCurrentTime } =
-    useContext(TimelineContext);
-  const setDurationTimeAndCapCurrentTime = useCallback(
-    (durationTimeValue: number) => {
-      setDurationTime(durationTimeValue);
-      setCurrentTime(Math.min(currentTime, durationTimeValue));
-    },
-    [currentTime]
-  );
+  const {
+    currentTime,
+    setCurrentTime,
+    currentTimeConfig,
+    durationTime,
+    setDurationTime,
+    durationTimeConfig,
+  } = useTime();
 
   return (
     <>
@@ -59,14 +35,10 @@ export const PlayControls = () => {
         <fieldset className="flex gap-1">
           <NumberInput
             value={durationTime}
-            onChange={setDurationTimeAndCapCurrentTime}
+            onChange={setDurationTime}
             data-testid="duration-input"
             validator={validateNumber}
-            config={{
-              step: durationTimeConfig.step,
-              min: durationTimeConfig.min,
-              max: durationTimeConfig.max,
-            }}
+            config={durationTimeConfig}
           />
           Duration
         </fieldset>

--- a/src/Timeline/Playhead.tsx
+++ b/src/Timeline/Playhead.tsx
@@ -3,7 +3,7 @@ import { TimelineContext } from "./TimelineContext";
 import { RenderTracker } from "./RenderTracker";
 
 export const Playhead = () => {
-  const { time } = useContext(TimelineContext);
+  const { currentTime } = useContext(TimelineContext);
 
   return (
     <>
@@ -11,7 +11,7 @@ export const Playhead = () => {
       <div
         className="absolute left-[316px] h-full border-l-2 border-solid border-yellow-600 z-10"
         data-testid="playhead"
-        style={{ transform: `translateX(calc(${time}px - 50%))` }}
+        style={{ transform: `translateX(calc(${currentTime}px - 50%))` }}
       >
         <div className="absolute border-solid border-[5px] border-transparent border-t-yellow-600 -translate-x-1.5" />
       </div>

--- a/src/Timeline/Ruler.spec.tsx
+++ b/src/Timeline/Ruler.spec.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Ruler } from "./Ruler";
+
+const mockSetCurrentTime = jest.fn();
+const currentTimeConfig = { step: 10, min: 0, max: 600 };
+const durationTime = 600;
+
+jest.mock("./useTime", () => ({
+  useTime: () => ({
+    setCurrentTime: mockSetCurrentTime,
+    currentTimeConfig,
+    durationTime,
+  }),
+}));
+
+describe("Ruler component", () => {
+  beforeEach(() => {
+    mockSetCurrentTime.mockClear();
+  });
+
+  test("clicking on the ruler sets current time based on click position", async () => {
+    render(<Ruler />);
+    const rulerBar = screen.getByTestId("ruler-bar");
+    jest.spyOn(rulerBar, "getBoundingClientRect").mockReturnValue({
+      left: 100,
+      top: 0,
+      right: 700,
+      bottom: 20,
+      width: 600,
+      height: 20,
+      x: 100,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    await userEvent.pointer({
+      target: rulerBar,
+      keys: "[MouseLeft]",
+      coords: { x: 252, y: 10 },
+    });
+    expect(mockSetCurrentTime).toHaveBeenCalledWith(150);
+  });
+
+  test("mouse move with left button pressed sets current time", async () => {
+    render(<Ruler />);
+    const rulerBar = screen.getByTestId("ruler-bar");
+    jest.spyOn(rulerBar, "getBoundingClientRect").mockReturnValue({
+      left: 50,
+      top: 0,
+      right: 650,
+      bottom: 20,
+      width: 600,
+      height: 20,
+      x: 50,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    await userEvent.pointer({
+      target: rulerBar,
+      keys: "[MouseLeft>]",
+      coords: { x: 52, y: 10 },
+    });
+    fireEvent.mouseMove(rulerBar, { clientX: 222, clientY: 10, buttons: 1 });
+    await userEvent.pointer({ target: rulerBar, keys: "[/MouseLeft]" });
+    expect(mockSetCurrentTime).toHaveBeenCalledWith(170);
+  });
+
+  test("mouse click without left button pressed does not update current time", async () => {
+    render(<Ruler />);
+    const rulerBar = screen.getByTestId("ruler-bar");
+    jest.spyOn(rulerBar, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 600,
+      bottom: 20,
+      width: 600,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    await userEvent.pointer({
+      target: rulerBar,
+      keys: "[MouseRight]",
+      coords: { x: 102, y: 10 },
+    });
+    expect(mockSetCurrentTime).not.toHaveBeenCalled();
+
+    await userEvent.pointer({
+      target: rulerBar,
+      keys: "[MouseLeft]",
+      coords: { x: 98, y: 10 },
+    });
+    expect(mockSetCurrentTime).toHaveBeenCalledWith(100);
+  });
+});

--- a/src/Timeline/Ruler.tsx
+++ b/src/Timeline/Ruler.tsx
@@ -1,8 +1,37 @@
-import { memo } from "react";
+import { memo, useCallback } from "react";
 import { RenderTracker } from "./RenderTracker";
+import { useTime } from "./useTime";
+import { validateNumber } from "./NumberInput";
 
 export const Ruler = () => {
   // TODO: implement mousedown and mousemove to update time and Playhead position
+  const { setCurrentTime, currentTimeConfig, durationTime } = useTime();
+
+  const handleClick = useCallback<
+    NonNullable<React.DOMAttributes<HTMLDivElement>["onClick"]>
+  >(
+    (e) => {
+      const { left } = e.currentTarget.getBoundingClientRect();
+      const clickX = e.clientX - left;
+      const millisecond = validateNumber(clickX, currentTimeConfig);
+      setCurrentTime(millisecond.result);
+    },
+    [currentTimeConfig]
+  );
+
+  const handleMouseMove = useCallback<
+    NonNullable<React.DOMAttributes<HTMLDivElement>["onMouseMove"]>
+  >(
+    (e) => {
+      if (e.buttons === 1) {
+        const { left } = e.currentTarget.getBoundingClientRect();
+        const mouseX = e.clientX - left;
+        const millisecond = validateNumber(mouseX, currentTimeConfig);
+        setCurrentTime(millisecond.result);
+      }
+    },
+    [currentTimeConfig]
+  );
 
   return (
     <>
@@ -14,8 +43,13 @@ export const Ruler = () => {
         data-testid="ruler"
       >
         <div
-          className="w-[2000px] h-6 rounded-md bg-white/25"
+          className="h-6 rounded-md bg-white/25"
           data-testid="ruler-bar"
+          style={{
+            width: `${durationTime}px`,
+          }}
+          onClick={handleClick}
+          onMouseMove={handleMouseMove}
         ></div>
       </div>
     </>

--- a/src/Timeline/Ruler.tsx
+++ b/src/Timeline/Ruler.tsx
@@ -4,7 +4,7 @@ import { useTime } from "./useTime";
 import { validateNumber } from "./NumberInput";
 
 export const Ruler = () => {
-  // TODO: implement mousedown and mousemove to update time and Playhead position
+  // TODO: implement mousedown and mousemove Playhead position
   const { setCurrentTime, currentTimeConfig, durationTime } = useTime();
 
   const handleClick = useCallback<

--- a/src/Timeline/Segment.tsx
+++ b/src/Timeline/Segment.tsx
@@ -1,8 +1,16 @@
+import { useTime } from "./useTime";
+
 export const Segment = () => {
-  // TODO: resize based on time
+  const { durationTime } = useTime();
 
   return (
-    <div className="w-[2000px] py-2" data-testid="segment">
+    <div
+      className="py-2"
+      data-testid="segment"
+      style={{
+        width: `${durationTime}px`,
+      }}
+    >
       <div className="h-6 rounded-md bg-white/10"></div>
     </div>
   );

--- a/src/Timeline/Timeline.spec.tsx
+++ b/src/Timeline/Timeline.spec.tsx
@@ -39,7 +39,7 @@ test("the components subscribed to the time state should render accordingly, whi
   await userEvent.keyboard("{Enter}");
   expect(playControlsRenderTracker.textContent).toBe("2");
   expect(playheadRenderTracker.textContent).toBe("2");
-  expect(rulerRenderTracker.textContent).toBe("1");
+  expect(rulerRenderTracker.textContent).toBe("2");
   expect(trackListRenderTracker.textContent).toBe("1");
   expect(keyframeListRenderTracker.textContent).toBe("1");
 });

--- a/src/Timeline/Timeline.tsx
+++ b/src/Timeline/Timeline.tsx
@@ -1,14 +1,42 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { PlayheadMemoed as Playhead } from "./Playhead";
 import { RulerMemoed as Ruler } from "./Ruler";
 import { TrackListMemoed as TrackList } from "./TrackList";
 import { KeyframeListMemoed as KeyframeList } from "./KeyframeList";
 import { PlayControlsMemoed as PlayControls } from "./PlayControls";
-import { TimelineContext } from "./TimelineContext";
+import { TimeConfig, TimelineContext } from "./TimelineContext";
 
 export const Timeline = () => {
-  const [time, setTime] = useState(0);
-  const timelineContextValue = { time, setTime };
+  const durationTimeConfig = useMemo<TimeConfig>(
+    () => ({
+      /**
+       * In unit of Milliseconds
+       */
+      step: 10,
+      min: 100,
+      max: 6000,
+    }),
+    []
+  );
+  const [currentTimeConfig, setCurrentTimeConfig] = useState<TimeConfig>({
+    /**
+     * In unit of Milliseconds
+     */
+    step: 10,
+    min: 0,
+    max: 6000,
+  });
+  const [currentTime, setCurrentTime] = useState(currentTimeConfig.min);
+  const [durationTime, setDurationTime] = useState(durationTimeConfig.max);
+  const timelineContextValue = {
+    currentTime,
+    setCurrentTime,
+    currentTimeConfig,
+    setCurrentTimeConfig,
+    durationTime,
+    setDurationTime,
+    durationTimeConfig,
+  };
 
   return (
     <div

--- a/src/Timeline/TimelineContext.ts
+++ b/src/Timeline/TimelineContext.ts
@@ -1,12 +1,27 @@
-import { createContext } from 'react';
+import { createContext } from "react";
+
+export type TimeConfig = {
+  step: number;
+  min: number;
+  max: number;
+};
 
 export type TimelineContext = {
-    time: number;
-    setTime: (v: number) => void;
-}
+  currentTime: number;
+  setCurrentTime: (v: number) => void;
+  currentTimeConfig: TimeConfig;
+  setCurrentTimeConfig: (v: TimeConfig) => void;
+  durationTime: number;
+  setDurationTime: (v: number) => void;
+  durationTimeConfig: TimeConfig;
+};
 
 export const TimelineContext = createContext<TimelineContext>({
-    time: 0,
-    setTime: () => {}
+  currentTime: 0,
+  setCurrentTime: () => {},
+  currentTimeConfig: { step: 1, min: 0, max: 100 },
+  setCurrentTimeConfig: () => {},
+  durationTime: 0,
+  setDurationTime: () => {},
+  durationTimeConfig: { step: 1, min: 0, max: 100 },
 });
-

--- a/src/Timeline/useTime.tsx
+++ b/src/Timeline/useTime.tsx
@@ -1,0 +1,35 @@
+import { useCallback, useContext } from "react";
+import { TimelineContext } from "./TimelineContext";
+
+export const useTime = () => {
+  const {
+    currentTime,
+    setCurrentTime,
+    currentTimeConfig,
+    setCurrentTimeConfig,
+    durationTime,
+    setDurationTime,
+    durationTimeConfig,
+  } = useContext(TimelineContext);
+
+  const setDurationTimeAndCapCurrentTime = useCallback(
+    (durationTimeValue: number) => {
+      setDurationTime(durationTimeValue);
+      setCurrentTime(Math.min(currentTime, durationTimeValue));
+      setCurrentTimeConfig({
+        ...currentTimeConfig,
+        max: durationTimeValue,
+      });
+    },
+    [currentTime, currentTimeConfig]
+  );
+
+  return {
+    currentTime,
+    setCurrentTime,
+    currentTimeConfig,
+    durationTime,
+    setDurationTime: setDurationTimeAndCapCurrentTime,
+    durationTimeConfig,
+  };
+};


### PR DESCRIPTION
## Summary

Implemented below requirements in `3. Ruler Behavior` and `5. Keyframe List Behavior`

- [x] Clicking or dragging on the Ruler updates the Current Time and Playhead position
- [x] Ruler length visually represents the total Duration (`1ms = 1px`)
- [x] Ruler length updates only after specific actions on Duration input (losing focus, pressing Enter, using arrow keys, or clicking up/down buttons)
- [x] Segment length visually represents the total Duration (`1ms = 1px`)
- [x] Segment length updates only after specific actions on Duration input (losing focus, pressing Enter, using arrow keys, or clicking up/down buttons)

## Todo
1. Show 0 (the minimum allowed value) when pressing non numeric keys (e.g. A, B) - Currently it stays as empty when pressing these keys, but the final value is correctly set to 0.
2. Correctly position Playhead.
3. Sync scrollings between components.