### PR TITLE
Feature: extend playhead and handle scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "loader-utils": "3.2.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-intersection-observer": "^9.15.1",
     "react-scripts": "5.0.1",
     "tailwindcss": "3.4.4"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@testing-library/react": "^16.0.0",
     "@types/jest": "^29.5.12",
     "@types/mocha": "^10.0.7",
+    "intersection-observer": "^0.12.2",
     "loader-utils": "3.2.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/Timeline/KeyframeList.tsx
+++ b/src/Timeline/KeyframeList.tsx
@@ -1,27 +1,35 @@
-import { memo } from "react";
+import { forwardRef, memo } from "react";
 import { Segment } from "./Segment";
 import { RenderTracker } from "./RenderTracker";
+import { ScrollSyncElement } from "./useScroll";
 
-export const KeyframeList = () => {
-  // TODO: implement scroll sync with `Ruler` and `TrackList`
+export type KeyframeListProps = ScrollSyncElement;
 
-  return (
-    <>
-      <RenderTracker dataTestId="keyframe-list-render-tracker" />
-      <div className="px-4 min-w-0 overflow-auto" data-testid="keyframe-list">
-        <Segment />
-        <Segment />
-        <Segment />
-        <Segment />
-        <Segment />
-        <Segment />
-        <Segment />
-        <Segment />
-        <Segment />
-        <Segment />
-      </div>
-    </>
-  );
-};
+export const KeyframeList = forwardRef<HTMLDivElement, KeyframeListProps>(
+  ({ onScroll }, ref) => {
+    return (
+      <>
+        <RenderTracker dataTestId="keyframe-list-render-tracker" />
+        <div
+          className="px-4 min-w-0 overflow-auto"
+          data-testid="keyframe-list"
+          ref={ref}
+          onScroll={onScroll}
+        >
+          <Segment />
+          <Segment />
+          <Segment />
+          <Segment />
+          <Segment />
+          <Segment />
+          <Segment />
+          <Segment />
+          <Segment />
+          <Segment />
+        </div>
+      </>
+    );
+  }
+);
 
 export const KeyframeListMemoed = memo(KeyframeList);

--- a/src/Timeline/NumberInput.tsx
+++ b/src/Timeline/NumberInput.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useRef, useState } from "react";
+import { useLatest } from "./useLatest";
 
 export type NumberConfig = {
   step: number;
@@ -75,15 +76,17 @@ export function NumberInput({
     inputElement.current?.select();
   }, []);
 
-  const handleValueChange = useCallback(
-    (localValue: string) => {
-      const rawValue = parseFloat(localValue);
-      const { result: validatedValue } = validator(rawValue, config);
-      onChange(validatedValue);
-      setLocalValue(validatedValue.toString());
-    },
-    [config, onChange]
-  );
+  const configLatest = useLatest(config);
+  const onChangeLatest = useLatest(onChange);
+  const handleValueChange = useCallback((localValue: string) => {
+    const rawValue = parseFloat(localValue);
+    const { result: validatedValue } = validator(
+      rawValue,
+      configLatest.current
+    );
+    onChangeLatest.current(validatedValue);
+    setLocalValue(validatedValue.toString());
+  }, []);
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/Timeline/PlayControls.spec.tsx
+++ b/src/Timeline/PlayControls.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PropsWithChildren, useState } from "react";
 import { PlayControls } from "./PlayControls";
-import { TimelineContext } from "./TimelineContext";
+import { TimeContext } from "./TimeContext";
 
 describe("PlayControls requirements", () => {
   const TimelineProvider = ({
@@ -18,7 +18,7 @@ describe("PlayControls requirements", () => {
     const currentTimeConfig = { step: 10, min: 0, max: 6000 };
     const durationTimeConfig = { step: 10, min: 100, max: 6000 };
     return (
-      <TimelineContext.Provider
+      <TimeContext.Provider
         value={{
           currentTime,
           setCurrentTime,
@@ -30,7 +30,7 @@ describe("PlayControls requirements", () => {
         }}
       >
         {children}
-      </TimelineContext.Provider>
+      </TimeContext.Provider>
     );
   };
 

--- a/src/Timeline/Playhead.tsx
+++ b/src/Timeline/Playhead.tsx
@@ -1,9 +1,9 @@
 import { memo, useContext } from "react";
-import { TimelineContext } from "./TimelineContext";
+import { TimeContext } from "./TimeContext";
 import { RenderTracker } from "./RenderTracker";
 
 export const Playhead = () => {
-  const { currentTime } = useContext(TimelineContext);
+  const { currentTime } = useContext(TimeContext);
 
   return (
     <>

--- a/src/Timeline/Playhead.tsx
+++ b/src/Timeline/Playhead.tsx
@@ -9,7 +9,7 @@ export const Playhead = () => {
     <>
       <RenderTracker dataTestId="playhead-render-tracker" />
       <div
-        className="absolute left-[316px] h-full border-l-2 border-solid border-yellow-600 z-10"
+        className="absolute left-[300px] ml-4 h-full border-l-2 border-solid border-yellow-600 z-10"
         data-testid="playhead"
         style={{ transform: `translateX(calc(${currentTime}px - 50%))` }}
       >

--- a/src/Timeline/Playhead.tsx
+++ b/src/Timeline/Playhead.tsx
@@ -1,9 +1,16 @@
 import { forwardRef, memo, useContext } from "react";
+import { useInView } from "react-intersection-observer";
 import { RenderTracker } from "./RenderTracker";
 import { TimeContext } from "./TimeContext";
 
 export const Playhead = forwardRef<HTMLDivElement>((_props, ref) => {
   const { currentTime, durationTime } = useContext(TimeContext);
+  const { ref: inViewRef, inView } = useInView({
+    threshold: 0,
+  });
+  const playheadStyle = {
+    transform: `translateX(calc(${currentTime}px - 50%))`,
+  };
 
   return (
     <>
@@ -19,10 +26,16 @@ export const Playhead = forwardRef<HTMLDivElement>((_props, ref) => {
           }}
         ></div>
         <div
+          className="absolute top-0 h-[2px] w-[2px] bg-transparent"
+          ref={inViewRef}
+          style={playheadStyle}
+        ></div>
+        <div
           className="absolute top-0 h-full border-l-2 border-solid border-yellow-600 z-10"
           data-testid="playhead"
-          style={{ transform: `translateX(calc(${currentTime}px - 50%))` }}
+          style={playheadStyle}
           ref={ref}
+          hidden={!inView}
         >
           <div className="absolute border-solid border-[5px] border-transparent border-t-yellow-600 -translate-x-1.5" />
         </div>

--- a/src/Timeline/Playhead.tsx
+++ b/src/Timeline/Playhead.tsx
@@ -1,22 +1,34 @@
-import { memo, useContext } from "react";
-import { TimeContext } from "./TimeContext";
+import { forwardRef, memo, useContext } from "react";
 import { RenderTracker } from "./RenderTracker";
+import { TimeContext } from "./TimeContext";
 
-export const Playhead = () => {
-  const { currentTime } = useContext(TimeContext);
+export const Playhead = forwardRef<HTMLDivElement>((_props, ref) => {
+  const { currentTime, durationTime } = useContext(TimeContext);
 
   return (
     <>
       <RenderTracker dataTestId="playhead-render-tracker" />
       <div
-        className="absolute left-[300px] ml-4 h-full border-l-2 border-solid border-yellow-600 z-10"
-        data-testid="playhead"
-        style={{ transform: `translateX(calc(${currentTime}px - 50%))` }}
+        className="min-w-0 h-full pointer-events-none px-4 absolute left-[300px] top-0 right-0 bottom-0 overflow-x-auto overflow-y-hidden"
+        ref={ref}
       >
-        <div className="absolute border-solid border-[5px] border-transparent border-t-yellow-600 -translate-x-1.5" />
+        <div
+          style={{
+            width: `${durationTime}px`,
+            height: "100%",
+          }}
+        ></div>
+        <div
+          className="absolute top-0 h-full border-l-2 border-solid border-yellow-600 z-10"
+          data-testid="playhead"
+          style={{ transform: `translateX(calc(${currentTime}px - 50%))` }}
+          ref={ref}
+        >
+          <div className="absolute border-solid border-[5px] border-transparent border-t-yellow-600 -translate-x-1.5" />
+        </div>
       </div>
     </>
   );
-};
+});
 
 export const PlayheadMemoed = memo(Playhead);

--- a/src/Timeline/Ruler.tsx
+++ b/src/Timeline/Ruler.tsx
@@ -9,7 +9,6 @@ export type RulerProps = ScrollSyncElement;
 
 export const Ruler = forwardRef<HTMLDivElement, RulerProps>(
   ({ onScroll }, ref) => {
-    // TODO: implement mousedown and mousemove Playhead position
     const { setCurrentTime, currentTimeConfig, durationTime } = useTime();
 
     const handleClick = useCallback<

--- a/src/Timeline/Ruler.tsx
+++ b/src/Timeline/Ruler.tsx
@@ -3,6 +3,7 @@ import { RenderTracker } from "./RenderTracker";
 import { useTime } from "./useTime";
 import { validateNumber } from "./NumberInput";
 import { ScrollSyncElement } from "./useScroll";
+import { useThrottleFn } from "./useThrottleFn";
 
 export type RulerProps = ScrollSyncElement;
 
@@ -36,6 +37,7 @@ export const Ruler = forwardRef<HTMLDivElement, RulerProps>(
       },
       [currentTimeConfig]
     );
+    const [handleMouseMoveThrottled] = useThrottleFn(handleMouseMove, 32);
 
     return (
       <>
@@ -55,7 +57,7 @@ export const Ruler = forwardRef<HTMLDivElement, RulerProps>(
               width: `${durationTime}px`,
             }}
             onClick={handleClick}
-            onMouseMove={handleMouseMove}
+            onMouseMove={handleMouseMoveThrottled}
           ></div>
         </div>
       </>

--- a/src/Timeline/Ruler.tsx
+++ b/src/Timeline/Ruler.tsx
@@ -1,59 +1,66 @@
-import { memo, useCallback } from "react";
+import { forwardRef, memo, useCallback } from "react";
 import { RenderTracker } from "./RenderTracker";
 import { useTime } from "./useTime";
 import { validateNumber } from "./NumberInput";
+import { ScrollSyncElement } from "./useScroll";
 
-export const Ruler = () => {
-  // TODO: implement mousedown and mousemove Playhead position
-  const { setCurrentTime, currentTimeConfig, durationTime } = useTime();
+export type RulerProps = ScrollSyncElement;
 
-  const handleClick = useCallback<
-    NonNullable<React.DOMAttributes<HTMLDivElement>["onClick"]>
-  >(
-    (e) => {
-      const { left } = e.currentTarget.getBoundingClientRect();
-      const clickX = e.clientX - left;
-      const millisecond = validateNumber(clickX, currentTimeConfig);
-      setCurrentTime(millisecond.result);
-    },
-    [currentTimeConfig]
-  );
+export const Ruler = forwardRef<HTMLDivElement, RulerProps>(
+  ({ onScroll }, ref) => {
+    // TODO: implement mousedown and mousemove Playhead position
+    const { setCurrentTime, currentTimeConfig, durationTime } = useTime();
 
-  const handleMouseMove = useCallback<
-    NonNullable<React.DOMAttributes<HTMLDivElement>["onMouseMove"]>
-  >(
-    (e) => {
-      if (e.buttons === 1) {
+    const handleClick = useCallback<
+      NonNullable<React.DOMAttributes<HTMLDivElement>["onClick"]>
+    >(
+      (e) => {
         const { left } = e.currentTarget.getBoundingClientRect();
-        const mouseX = e.clientX - left;
-        const millisecond = validateNumber(mouseX, currentTimeConfig);
+        const clickX = e.clientX - left;
+        const millisecond = validateNumber(clickX, currentTimeConfig);
         setCurrentTime(millisecond.result);
-      }
-    },
-    [currentTimeConfig]
-  );
+      },
+      [currentTimeConfig]
+    );
 
-  return (
-    <>
-      <RenderTracker dataTestId="ruler-render-tracker" />
-      <div
-        className="px-4 py-2 min-w-0 
+    const handleMouseMove = useCallback<
+      NonNullable<React.DOMAttributes<HTMLDivElement>["onMouseMove"]>
+    >(
+      (e) => {
+        if (e.buttons === 1) {
+          const { left } = e.currentTarget.getBoundingClientRect();
+          const mouseX = e.clientX - left;
+          const millisecond = validateNumber(mouseX, currentTimeConfig);
+          setCurrentTime(millisecond.result);
+        }
+      },
+      [currentTimeConfig]
+    );
+
+    return (
+      <>
+        <RenderTracker dataTestId="ruler-render-tracker" />
+        <div
+          className="px-4 py-2 min-w-0 
       border-b border-solid border-gray-700 
       overflow-x-auto overflow-y-hidden"
-        data-testid="ruler"
-      >
-        <div
-          className="h-6 rounded-md bg-white/25"
-          data-testid="ruler-bar"
-          style={{
-            width: `${durationTime}px`,
-          }}
-          onClick={handleClick}
-          onMouseMove={handleMouseMove}
-        ></div>
-      </div>
-    </>
-  );
-};
+          data-testid="ruler"
+          ref={ref}
+          onScroll={onScroll}
+        >
+          <div
+            className="h-6 rounded-md bg-white/25"
+            data-testid="ruler-bar"
+            style={{
+              width: `${durationTime}px`,
+            }}
+            onClick={handleClick}
+            onMouseMove={handleMouseMove}
+          ></div>
+        </div>
+      </>
+    );
+  }
+);
 
 export const RulerMemoed = memo(Ruler);

--- a/src/Timeline/Ruler.tsx
+++ b/src/Timeline/Ruler.tsx
@@ -4,39 +4,41 @@ import { useTime } from "./useTime";
 import { validateNumber } from "./NumberInput";
 import { ScrollSyncElement } from "./useScroll";
 import { useThrottleFn } from "./useThrottleFn";
+import { useLatest } from "./useLatest";
 
 export type RulerProps = ScrollSyncElement;
 
 export const Ruler = forwardRef<HTMLDivElement, RulerProps>(
   ({ onScroll }, ref) => {
     const { setCurrentTime, currentTimeConfig, durationTime } = useTime();
+    const currentTimeConfigLatest = useLatest(currentTimeConfig);
 
     const handleClick = useCallback<
       NonNullable<React.DOMAttributes<HTMLDivElement>["onClick"]>
-    >(
-      (e) => {
-        const { left } = e.currentTarget.getBoundingClientRect();
-        const clickX = e.clientX - left;
-        const millisecond = validateNumber(clickX, currentTimeConfig);
-        setCurrentTime(millisecond.result);
-      },
-      [currentTimeConfig]
-    );
+    >((e) => {
+      const { left } = e.currentTarget.getBoundingClientRect();
+      const clickX = e.clientX - left;
+      const millisecond = validateNumber(
+        clickX,
+        currentTimeConfigLatest.current
+      );
+      setCurrentTime(millisecond.result);
+    }, []);
 
     const handleMouseMove = useCallback<
       NonNullable<React.DOMAttributes<HTMLDivElement>["onMouseMove"]>
-    >(
-      (e) => {
-        if (e.buttons === 1) {
-          const { left } = e.currentTarget.getBoundingClientRect();
-          const mouseX = e.clientX - left;
-          const millisecond = validateNumber(mouseX, currentTimeConfig);
-          setCurrentTime(millisecond.result);
-        }
-      },
-      [currentTimeConfig]
-    );
-    const [handleMouseMoveThrottled] = useThrottleFn(handleMouseMove, 32);
+    >((e) => {
+      if (e.buttons === 1) {
+        const { left } = e.currentTarget.getBoundingClientRect();
+        const mouseX = e.clientX - left;
+        const millisecond = validateNumber(
+          mouseX,
+          currentTimeConfigLatest.current
+        );
+        setCurrentTime(millisecond.result);
+      }
+    }, []);
+    const [handleMouseMoveThrottled] = useThrottleFn(handleMouseMove, 32); // 30FPS
 
     return (
       <>

--- a/src/Timeline/TimeContext.ts
+++ b/src/Timeline/TimeContext.ts
@@ -6,7 +6,7 @@ export type TimeConfig = {
   max: number;
 };
 
-export type TimelineContext = {
+export type TimeContext = {
   currentTime: number;
   setCurrentTime: (v: number) => void;
   currentTimeConfig: TimeConfig;
@@ -16,7 +16,7 @@ export type TimelineContext = {
   durationTimeConfig: TimeConfig;
 };
 
-export const TimelineContext = createContext<TimelineContext>({
+export const TimeContext = createContext<TimeContext>({
   currentTime: 0,
   setCurrentTime: () => {},
   currentTimeConfig: { step: 1, min: 0, max: 100 },

--- a/src/Timeline/Timeline.spec.tsx
+++ b/src/Timeline/Timeline.spec.tsx
@@ -30,7 +30,7 @@ test("the components subscribed to the time state should render accordingly, whi
   // Initial render
   expect(playControlsRenderTracker.textContent).toBe("1");
   expect(rulerRenderTracker.textContent).toBe("1");
-  expect(playheadRenderTracker.textContent).toBe("1");
+  expect(playheadRenderTracker.textContent).toBe("2"); // useInView created 2 render
   expect(trackListRenderTracker.textContent).toBe("1");
   expect(keyframeListRenderTracker.textContent).toBe("1");
 
@@ -38,7 +38,7 @@ test("the components subscribed to the time state should render accordingly, whi
   await userEvent.type(currentTimeInput, "20");
   await userEvent.keyboard("{Enter}");
   expect(playControlsRenderTracker.textContent).toBe("2");
-  expect(playheadRenderTracker.textContent).toBe("2");
+  expect(playheadRenderTracker.textContent).toBe("3");
   expect(rulerRenderTracker.textContent).toBe("2");
   expect(trackListRenderTracker.textContent).toBe("1");
   expect(keyframeListRenderTracker.textContent).toBe("1");

--- a/src/Timeline/Timeline.tsx
+++ b/src/Timeline/Timeline.tsx
@@ -8,6 +8,9 @@ import { TrackListMemoed as TrackList } from "./TrackList";
 import { useScroll } from "./useScroll";
 
 export const Timeline = () => {
+  /**
+   * Time context
+   */
   const durationTimeConfig = useMemo<TimeConfig>(
     () => ({
       /**
@@ -38,6 +41,10 @@ export const Timeline = () => {
     setDurationTime,
     durationTimeConfig,
   };
+
+  /**
+   * Scroll behavior
+   */
   const rulerRef = useRef<HTMLDivElement>(null);
   const keyframeListRef = useRef<HTMLDivElement>(null);
   const trackListRef = useRef<HTMLDivElement>(null);

--- a/src/Timeline/Timeline.tsx
+++ b/src/Timeline/Timeline.tsx
@@ -11,17 +11,14 @@ export const Timeline = () => {
   /**
    * Time context
    */
-  const durationTimeConfig = useMemo<TimeConfig>(
-    () => ({
-      /**
-       * In unit of Milliseconds
-       */
-      step: 10,
-      min: 100,
-      max: 6000,
-    }),
-    []
-  );
+  const durationTimeConfig: TimeConfig = {
+    /**
+     * In unit of Milliseconds
+     */
+    step: 10,
+    min: 100,
+    max: 6000,
+  };
   const [currentTimeConfig, setCurrentTimeConfig] = useState<TimeConfig>({
     /**
      * In unit of Milliseconds

--- a/src/Timeline/Timeline.tsx
+++ b/src/Timeline/Timeline.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from "react";
-import { PlayheadMemoed as Playhead } from "./Playhead";
-import { RulerMemoed as Ruler } from "./Ruler";
-import { TrackListMemoed as TrackList } from "./TrackList";
+import { useMemo, useRef, useState } from "react";
 import { KeyframeListMemoed as KeyframeList } from "./KeyframeList";
 import { PlayControlsMemoed as PlayControls } from "./PlayControls";
+import { PlayheadMemoed as Playhead } from "./Playhead";
+import { RulerMemoed as Ruler } from "./Ruler";
 import { TimeConfig, TimeContext } from "./TimeContext";
+import { TrackListMemoed as TrackList } from "./TrackList";
+import { useScroll } from "./useScroll";
 
 export const Timeline = () => {
   const durationTimeConfig = useMemo<TimeConfig>(
@@ -37,6 +38,16 @@ export const Timeline = () => {
     setDurationTime,
     durationTimeConfig,
   };
+  const rulerRef = useRef<HTMLDivElement>(null);
+  const keyframeListRef = useRef<HTMLDivElement>(null);
+  const trackListRef = useRef<HTMLDivElement>(null);
+  const { syncScrollX, syncScrollY, syncBothScroll } = useScroll({
+    scrollXElements: [() => rulerRef.current, () => keyframeListRef.current],
+    scrollYElements: [
+      () => keyframeListRef.current,
+      () => trackListRef.current,
+    ],
+  });
 
   return (
     <div
@@ -46,9 +57,9 @@ export const Timeline = () => {
     >
       <TimeContext.Provider value={timeContextValue}>
         <PlayControls />
-        <Ruler />
-        <TrackList />
-        <KeyframeList />
+        <Ruler ref={rulerRef} onScroll={syncScrollX} />
+        <TrackList ref={trackListRef} onScroll={syncScrollY} />
+        <KeyframeList ref={keyframeListRef} onScroll={syncBothScroll} />
         <Playhead />
       </TimeContext.Provider>
     </div>

--- a/src/Timeline/Timeline.tsx
+++ b/src/Timeline/Timeline.tsx
@@ -48,8 +48,13 @@ export const Timeline = () => {
   const rulerRef = useRef<HTMLDivElement>(null);
   const keyframeListRef = useRef<HTMLDivElement>(null);
   const trackListRef = useRef<HTMLDivElement>(null);
+  const playheadRef = useRef<HTMLDivElement>(null);
   const { syncScrollX, syncScrollY, syncBothScroll } = useScroll({
-    scrollXElements: [() => rulerRef.current, () => keyframeListRef.current],
+    scrollXElements: [
+      () => rulerRef.current,
+      () => keyframeListRef.current,
+      () => playheadRef.current,
+    ],
     scrollYElements: [
       () => keyframeListRef.current,
       () => trackListRef.current,
@@ -67,7 +72,7 @@ export const Timeline = () => {
         <Ruler ref={rulerRef} onScroll={syncScrollX} />
         <TrackList ref={trackListRef} onScroll={syncScrollY} />
         <KeyframeList ref={keyframeListRef} onScroll={syncBothScroll} />
-        <Playhead />
+        <Playhead ref={playheadRef} />
       </TimeContext.Provider>
     </div>
   );

--- a/src/Timeline/Timeline.tsx
+++ b/src/Timeline/Timeline.tsx
@@ -4,7 +4,7 @@ import { RulerMemoed as Ruler } from "./Ruler";
 import { TrackListMemoed as TrackList } from "./TrackList";
 import { KeyframeListMemoed as KeyframeList } from "./KeyframeList";
 import { PlayControlsMemoed as PlayControls } from "./PlayControls";
-import { TimeConfig, TimelineContext } from "./TimelineContext";
+import { TimeConfig, TimeContext } from "./TimeContext";
 
 export const Timeline = () => {
   const durationTimeConfig = useMemo<TimeConfig>(
@@ -28,7 +28,7 @@ export const Timeline = () => {
   });
   const [currentTime, setCurrentTime] = useState(currentTimeConfig.min);
   const [durationTime, setDurationTime] = useState(durationTimeConfig.max);
-  const timelineContextValue = {
+  const timeContextValue = {
     currentTime,
     setCurrentTime,
     currentTimeConfig,
@@ -44,13 +44,13 @@ export const Timeline = () => {
     bg-gray-800 border-t-2 border-solid border-gray-700"
       data-testid="timeline"
     >
-      <TimelineContext.Provider value={timelineContextValue}>
+      <TimeContext.Provider value={timeContextValue}>
         <PlayControls />
         <Ruler />
         <TrackList />
         <KeyframeList />
         <Playhead />
-      </TimelineContext.Provider>
+      </TimeContext.Provider>
     </div>
   );
 };

--- a/src/Timeline/TrackList.tsx
+++ b/src/Timeline/TrackList.tsx
@@ -1,6 +1,14 @@
 import { memo } from "react";
 import { RenderTracker } from "./RenderTracker";
 
+const Track = ({ name }: { name: string }) => {
+  return (
+    <div className="p-2 select-none">
+      <div>{name}</div>
+    </div>
+  );
+};
+
 export const TrackList = () => {
   // TODO: implement scroll sync with `KeyframeList`
 
@@ -13,36 +21,16 @@ export const TrackList = () => {
       overflow-auto"
         data-testid="track-list"
       >
-        <div className="p-2">
-          <div>Track A</div>
-        </div>
-        <div className="p-2">
-          <div>Track B</div>
-        </div>
-        <div className="p-2">
-          <div>Track C</div>
-        </div>
-        <div className="p-2">
-          <div>Track D</div>
-        </div>
-        <div className="p-2">
-          <div>Track E</div>
-        </div>
-        <div className="p-2">
-          <div>Track F </div>
-        </div>
-        <div className="p-2">
-          <div>Track G</div>
-        </div>
-        <div className="p-2">
-          <div>Track H</div>
-        </div>
-        <div className="p-2">
-          <div>Track I </div>
-        </div>
-        <div className="p-2">
-          <div>Track J</div>
-        </div>
+        <Track name="Track A" />
+        <Track name="Track B" />
+        <Track name="Track C" />
+        <Track name="Track D" />
+        <Track name="Track E" />
+        <Track name="Track F" />
+        <Track name="Track G" />
+        <Track name="Track H" />
+        <Track name="Track I" />
+        <Track name="Track J" />
       </div>
     </>
   );

--- a/src/Timeline/TrackList.tsx
+++ b/src/Timeline/TrackList.tsx
@@ -1,5 +1,6 @@
-import { memo } from "react";
+import { forwardRef, memo } from "react";
 import { RenderTracker } from "./RenderTracker";
+import { ScrollSyncElement } from "./useScroll";
 
 const Track = ({ name }: { name: string }) => {
   return (
@@ -9,31 +10,35 @@ const Track = ({ name }: { name: string }) => {
   );
 };
 
-export const TrackList = () => {
-  // TODO: implement scroll sync with `KeyframeList`
+export type TrackListProps = ScrollSyncElement;
 
-  return (
-    <>
-      <RenderTracker dataTestId="track-list-render-tracker" />
-      <div
-        className="grid grid-flow-row auto-rows-[40px]
+export const TrackList = forwardRef<HTMLDivElement, TrackListProps>(
+  ({ onScroll }, ref) => {
+    return (
+      <>
+        <RenderTracker dataTestId="track-list-render-tracker" />
+        <div
+          className="grid grid-flow-row auto-rows-[40px]
       border-r border-solid border-r-gray-700 
       overflow-auto"
-        data-testid="track-list"
-      >
-        <Track name="Track A" />
-        <Track name="Track B" />
-        <Track name="Track C" />
-        <Track name="Track D" />
-        <Track name="Track E" />
-        <Track name="Track F" />
-        <Track name="Track G" />
-        <Track name="Track H" />
-        <Track name="Track I" />
-        <Track name="Track J" />
-      </div>
-    </>
-  );
-};
+          data-testid="track-list"
+          ref={ref}
+          onScroll={onScroll}
+        >
+          <Track name="Track A" />
+          <Track name="Track B" />
+          <Track name="Track C" />
+          <Track name="Track D" />
+          <Track name="Track E" />
+          <Track name="Track F" />
+          <Track name="Track G" />
+          <Track name="Track H" />
+          <Track name="Track I" />
+          <Track name="Track J" />
+        </div>
+      </>
+    );
+  }
+);
 
 export const TrackListMemoed = memo(TrackList);

--- a/src/Timeline/useLatest.tsx
+++ b/src/Timeline/useLatest.tsx
@@ -1,0 +1,12 @@
+/**
+ * https://github.com/streamich/react-use/blob/master/src/useLatest.ts
+ */
+import { useRef } from "react";
+
+export const useLatest = <T extends unknown>(
+  value: T
+): { readonly current: T } => {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+};

--- a/src/Timeline/useScroll.tsx
+++ b/src/Timeline/useScroll.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
+import { useLatest } from "./useLatest";
 
 export type ScrollSyncElement = Pick<
   React.DOMAttributes<HTMLElement>,
@@ -32,10 +33,8 @@ export const useScroll = ({
   scrollXElements,
   scrollYElements,
 }: UseScrollProps) => {
-  const scrollXElementsLatest = useRef(scrollXElements);
-  const scrollYElementsLatest = useRef(scrollYElements);
-  scrollXElementsLatest.current = scrollXElements;
-  scrollYElementsLatest.current = scrollYElements;
+  const scrollXElementsLatest = useLatest(scrollXElements);
+  const scrollYElementsLatest = useLatest(scrollYElements);
 
   const syncScrollX = useCallback<
     NonNullable<React.DOMAttributes<HTMLElement>["onScroll"]>

--- a/src/Timeline/useScroll.tsx
+++ b/src/Timeline/useScroll.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useRef } from "react";
+
+export type ScrollSyncElement = Pick<
+  React.DOMAttributes<HTMLElement>,
+  "onScroll"
+>;
+
+export type UseScrollProps = {
+  scrollXElements: Array<() => HTMLElement | null>;
+  scrollYElements: Array<() => HTMLElement | null>;
+};
+
+function syncElementScrollPosition(
+  targetElement: HTMLElement,
+  allElements: Array<() => HTMLElement | null>,
+  scrollType: "scrollLeft" | "scrollTop"
+) {
+  const nextScroll = targetElement[scrollType];
+  allElements.forEach((getter) => {
+    const element = getter();
+    if (
+      element !== targetElement &&
+      element !== null &&
+      element[scrollType] !== nextScroll
+    ) {
+      element[scrollType] = nextScroll;
+    }
+  });
+}
+
+export const useScroll = ({
+  scrollXElements,
+  scrollYElements,
+}: UseScrollProps) => {
+  const scrollXElementsLatest = useRef(scrollXElements);
+  const scrollYElementsLatest = useRef(scrollYElements);
+  scrollXElementsLatest.current = scrollXElements;
+  scrollYElementsLatest.current = scrollYElements;
+
+  const syncScrollX = useCallback<
+    NonNullable<React.DOMAttributes<HTMLElement>["onScroll"]>
+  >((e) => {
+    syncElementScrollPosition(
+      e.currentTarget,
+      scrollXElementsLatest.current,
+      "scrollLeft"
+    );
+  }, []);
+  const syncScrollY = useCallback<
+    NonNullable<React.DOMAttributes<HTMLElement>["onScroll"]>
+  >((e) => {
+    syncElementScrollPosition(
+      e.currentTarget,
+      scrollYElementsLatest.current,
+      "scrollTop"
+    );
+  }, []);
+  const syncBothScroll = useCallback<typeof syncScrollX>(
+    (e) => {
+      syncScrollX(e);
+      syncScrollY(e);
+    },
+    [syncScrollX, syncScrollY]
+  );
+
+  return {
+    syncScrollX,
+    syncScrollY,
+    syncBothScroll,
+  };
+};

--- a/src/Timeline/useThrottleFn.ts
+++ b/src/Timeline/useThrottleFn.ts
@@ -1,0 +1,45 @@
+/**
+ * https://github.com/afiiif/react-power-ups/blob/main/src/use-throttle-fn.ts
+ * And modified...
+ */
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Throttles a function.
+ *
+ * •
+ *
+ * @param {Function} fn Function to be throttled.
+ * @param {number} delay Delay in milliseconds.
+ */
+export function useThrottleFn<T extends unknown[]>(
+  fn: (...params: T) => void,
+  delay: number
+): [(...params: T) => void, () => void] {
+  const timeout = useRef<NodeJS.Timeout>();
+
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  const throttledFn = useCallback(
+    (...params: T) => {
+      if (!timeout.current) {
+        fnRef.current(...params);
+
+        timeout.current = setTimeout(() => {
+          timeout.current = undefined;
+        }, delay);
+      }
+    },
+    [delay]
+  );
+
+  const clear = useCallback(() => {
+    clearTimeout(timeout.current);
+    timeout.current = undefined;
+  }, []);
+
+  useEffect(() => clear, [clear]);
+
+  return [throttledFn, clear];
+}

--- a/src/Timeline/useTime.tsx
+++ b/src/Timeline/useTime.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext } from "react";
-import { TimelineContext } from "./TimelineContext";
+import { TimeContext } from "./TimeContext";
 
 export const useTime = () => {
   const {
@@ -10,7 +10,7 @@ export const useTime = () => {
     durationTime,
     setDurationTime,
     durationTimeConfig,
-  } = useContext(TimelineContext);
+  } = useContext(TimeContext);
 
   const setDurationTimeAndCapCurrentTime = useCallback(
     (durationTimeValue: number) => {

--- a/src/Timeline/useTime.tsx
+++ b/src/Timeline/useTime.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext } from "react";
 import { TimeContext } from "./TimeContext";
+import { useLatest } from "./useLatest";
 
 export const useTime = () => {
   const {
@@ -12,16 +13,18 @@ export const useTime = () => {
     durationTimeConfig,
   } = useContext(TimeContext);
 
+  const currentTimeLatest = useLatest(currentTime);
+  const currentTimeConfigLatest = useLatest(currentTimeConfig);
   const setDurationTimeAndCapCurrentTime = useCallback(
     (durationTimeValue: number) => {
       setDurationTime(durationTimeValue);
-      setCurrentTime(Math.min(currentTime, durationTimeValue));
+      setCurrentTime(Math.min(currentTimeLatest.current, durationTimeValue));
       setCurrentTimeConfig({
-        ...currentTimeConfig,
+        ...currentTimeConfigLatest.current,
         max: durationTimeValue,
       });
     },
-    [currentTime, currentTimeConfig]
+    []
   );
 
   return {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,4 @@
 // react-testing-library renders your components to document.body,
 // this adds jest-dom's custom assertions
 import "@testing-library/jest-dom";
+import "intersection-observer";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5481,6 +5481,11 @@ internal-slot@^1.0.4, internal-slot@^1.0.7:
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
+intersection-observer@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.2.tgz#4a45349cc0cd91916682b1f44c28d7ec737dc375"
+  integrity sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8079,6 +8079,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-intersection-observer@^9.15.1:
+  version "9.15.1"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.15.1.tgz#5866b6fdfef24be9f288b74b35b773f63d90c3eb"
+  integrity sha512-vGrqYEVWXfH+AGu241uzfUpNK4HAdhCkSAyFdkMb9VWWXs6mxzBLpWCxEy9YcnDNY2g9eO6z7qUtTBdA9hc8pA==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Summary

Implemented below requirements.

### 3. Ruler Behavior

- [x] Horizontal scrolling of the Ruler is synchronized with the Keyframe List

### 4. Track List Behavior

- [x] Vertical scrolling of the Track List is synchronized with the Keyframe List

### 5. Keyframe List Behavior

- [x] Vertical scrolling is synchronized with the Track List
- [x] Horizontal scrolling is synchronized with the Ruler

### 6. Playhead Behavior

- [x] Playhead moves in sync with the Ruler and Keyframe List during horizontal scrolling
- [x] Playhead maintains its relative position during horizontal scrolling
- [x] Playhead is visible only when within the Timeline's visible area, using the `hidden` attribute when completely out of view

## Technical details

1. Installed `react-intersection-observer` for the handy `useInView` hook to fulfill the requirement of adding `hidden` attribute to the Playhead component.
2. Copied `useLatest` from `react-use`: a handy hook to get the latest value of a prop, so that the dependency array could be cleaner.
3. Copied `useThrottleFn` from a public repository and slightly modified it for making it cleaner. This is to support throttling `onMouseMove` in Ruler component. 

## Todo
1. Show 0 (the minimum allowed value) when pressing non numeric keys (e.g. A, B) - Currently it stays as empty when pressing these keys, but the final value is correctly set to 0.
2. Add more test cases.