### PR TITLE
Feature: display the min value when pressing non numeric keys

### DIFF
--- a/src/Timeline/NumberInput.spec.tsx
+++ b/src/Timeline/NumberInput.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React, { createContext, useContext, useRef, useState } from "react";
 import { NumberInput, NumberInputProps, validateNumber } from "./NumberInput";
+import { clickAndType } from "./test-util";
 
 describe("NumberInput requirements", () => {
   type NumberContextValue = {
@@ -118,8 +119,7 @@ describe("NumberInput requirements", () => {
       await userEvent.click(input);
       expect(document.activeElement).toBe(input);
 
-      await userEvent.clear(input);
-      await userEvent.type(input, "25");
+      await clickAndType(input, "25");
       expect(onChangeSpy).toHaveBeenCalledTimes(0);
 
       await userEvent.click(container);
@@ -214,8 +214,7 @@ describe("NumberInput requirements", () => {
       expect(document.activeElement).toBe(input);
       expect(onChangeSpy).toHaveBeenCalledTimes(0);
 
-      await userEvent.clear(input);
-      await userEvent.type(input, "45");
+      await clickAndType(input, "45");
       expect(onChangeSpy).toHaveBeenCalledTimes(0);
 
       await userEvent.keyboard("{Enter}");
@@ -241,8 +240,7 @@ describe("NumberInput requirements", () => {
       expect(document.activeElement).toBe(input);
       expect(onChangeSpy).toHaveBeenCalledTimes(0);
 
-      await userEvent.clear(input);
-      await userEvent.type(input, "15");
+      await clickAndType(input, "15");
       expect(input.value).toBe("15");
       expect(onChangeSpy).toHaveBeenCalledTimes(0);
 
@@ -322,8 +320,7 @@ describe("NumberInput requirements", () => {
       await userEvent.click(input);
       expect(document.activeElement).toBe(input);
 
-      await userEvent.clear(input);
-      await userEvent.type(input, "55");
+      await clickAndType(input, "55");
       await userEvent.keyboard("{Escape}");
       expect(input.value).toBe("50");
       expect(document.activeElement).not.toBe(input);
@@ -358,9 +355,7 @@ describe("NumberInput requirements", () => {
       await userEvent.click(input2);
       expect(input1.value).toBe("50");
 
-      await userEvent.click(input1);
-      await userEvent.clear(input1);
-      await userEvent.type(input1, "100");
+      await clickAndType(input1, "100");
       await userEvent.keyboard("{Enter}");
       expect(input1.value).toBe("100");
       expect(input2.value).toBe("100");
@@ -379,9 +374,7 @@ describe("NumberInput requirements", () => {
       );
       const input = getByRole("spinbutton") as HTMLInputElement;
 
-      await userEvent.click(input);
-      await userEvent.clear(input);
-      await userEvent.type(input, "00100");
+      await clickAndType(input, "00100");
       expect(input).not.toHaveAttribute("data-invalid"); // Currently count as valid because this can represent a number
 
       await userEvent.tab();
@@ -415,10 +408,8 @@ describe("NumberInput requirements", () => {
       );
       const input = getByRole("spinbutton") as HTMLInputElement;
 
-      await userEvent.click(input);
-      await userEvent.clear(input);
-      await userEvent.type(input, "-5");
-      expect(input.value).toBe("-5");
+      await clickAndType(input, "-4");
+      expect(input.value).toBe("4"); // Because typing "-" is non effective
       expect(input).toHaveAttribute("data-invalid", "true");
 
       await userEvent.tab();
@@ -434,9 +425,7 @@ describe("NumberInput requirements", () => {
       );
       const input = getByRole("spinbutton") as HTMLInputElement;
 
-      await userEvent.click(input);
-      await userEvent.clear(input);
-      await userEvent.type(input, "15.6");
+      await clickAndType(input, "15.6");
       expect(input).toHaveAttribute("data-invalid", "true");
 
       await userEvent.tab();
@@ -446,16 +435,16 @@ describe("NumberInput requirements", () => {
 
     test("Invalid inputs (non-numeric) revert to the previous valid value", async () => {
       const { getByRole } = render(
-        <NumberProvider initialValue={10}>
+        <NumberProvider initialValue={0}>
           <NumberInputWrapper validator={validatorSpy} config={config} />
         </NumberProvider>
       );
       const input = getByRole("spinbutton") as HTMLInputElement;
+      expect(input.value).toBe("0");
 
-      await userEvent.click(input);
-      await userEvent.clear(input);
-      await userEvent.type(input, "abc");
-      expect(input).toHaveAttribute("data-invalid", "true");
+      await clickAndType(input, "abc"); // All these keys are non-effective
+      expect(input.value).toBe("0");
+      expect(input).not.toHaveAttribute("data-invalid");
 
       await userEvent.tab();
       expect(input.value).toBe("0");

--- a/src/Timeline/NumberInput.spec.tsx
+++ b/src/Timeline/NumberInput.spec.tsx
@@ -433,16 +433,17 @@ describe("NumberInput requirements", () => {
       expect(input).not.toHaveAttribute("data-invalid");
     });
 
-    test("Invalid inputs (non-numeric) revert to the previous valid value", async () => {
+    test.skip("Invalid inputs (non-numeric) changes to the to the minimum allowed value", async () => {
       const { getByRole } = render(
-        <NumberProvider initialValue={0}>
+        <NumberProvider initialValue={10}>
           <NumberInputWrapper validator={validatorSpy} config={config} />
         </NumberProvider>
       );
       const input = getByRole("spinbutton") as HTMLInputElement;
-      expect(input.value).toBe("0");
+      expect(input.value).toBe("10");
 
       await clickAndType(input, "abc"); // All these keys are non-effective
+      // NOTE should be "0", but seems that JSDOM is not simulating the correct behavior so it is still "10"
       expect(input.value).toBe("0");
       expect(input).not.toHaveAttribute("data-invalid");
 
@@ -466,6 +467,25 @@ describe("NumberInput requirements", () => {
 
       await userEvent.tab();
       expect(input.value).toBe("0");
+      expect(input).not.toHaveAttribute("data-invalid");
+    });
+
+    test.skip("Complete number representation is accepted", async () => {
+      const { getByRole } = render(
+        <NumberProvider initialValue={10}>
+          <NumberInputWrapper validator={validatorSpy} config={config} />
+        </NumberProvider>
+      );
+      const input = getByRole("spinbutton") as HTMLInputElement;
+      expect(input.value).toBe("10");
+
+      await userEvent.click(input);
+      await userEvent.paste("1e+2");
+      expect(input.value).toBe("1e+2");
+      expect(input).not.toHaveAttribute("data-invalid");
+
+      await userEvent.tab();
+      expect(input.value).toBe("100");
       expect(input).not.toHaveAttribute("data-invalid");
     });
 

--- a/src/Timeline/NumberInput.spec.tsx
+++ b/src/Timeline/NumberInput.spec.tsx
@@ -451,6 +451,24 @@ describe("NumberInput requirements", () => {
       expect(input).not.toHaveAttribute("data-invalid");
     });
 
+    test("Incomplete number representation changes to to the minimum allowed value", async () => {
+      const { getByRole } = render(
+        <NumberProvider initialValue={10}>
+          <NumberInputWrapper validator={validatorSpy} config={config} />
+        </NumberProvider>
+      );
+      const input = getByRole("spinbutton") as HTMLInputElement;
+      expect(input.value).toBe("10");
+
+      await clickAndType(input, "1e");
+      expect(input.value).toBe("0");
+      expect(input).not.toHaveAttribute("data-invalid");
+
+      await userEvent.tab();
+      expect(input.value).toBe("0");
+      expect(input).not.toHaveAttribute("data-invalid");
+    });
+
     test("If config changes, the validation result should reflect it accordingly", async () => {
       const config1 = {
         step: 1,

--- a/src/Timeline/NumberInput.tsx
+++ b/src/Timeline/NumberInput.tsx
@@ -91,16 +91,16 @@ export function NumberInput({
       if (isSpinnerClicked.current || isArrowKeyDown.current) {
         handleValueChange(e.target.value);
         selectInputText();
-      }
-      // TODO this messes up the entering of "-" and "." etc.
-      // Need to find a better way to handle typing of e.g. A,B,C.
-      // else if (e.target.value === "") {
-      //   setLocalValue(min?.toString() ?? "0");
-      // }
-      else {
+      } else if (e.target.value === "") {
+        // Empty target value means the current input is not a valid number
+        setLocalValue(configLatest.current.min.toString() ?? "0");
+      } else {
         setLocalValue(e.target.value);
 
-        const { hasError } = validator(parseFloat(e.target.value), config);
+        const { hasError } = validator(
+          parseFloat(e.target.value),
+          configLatest.current
+        );
         setHasError(hasError);
       }
     },

--- a/src/Timeline/NumberInput.tsx
+++ b/src/Timeline/NumberInput.tsx
@@ -19,7 +19,7 @@ export function validateNumber(rawTime: number, config: NumberConfig) {
   if (hasError) {
     if (Number.isNaN(result) || result === -Infinity) {
       result = config.min;
-    } else if (result === Infinity) {
+    } else {
       result = config.max;
     }
   }
@@ -116,10 +116,7 @@ export function NumberInput({
   const handleBlur = () => {
     if (blurTriggerKey.current === "Escape") {
       setLocalValue(valueString);
-    } else if (
-      blurTriggerKey.current === "Enter" ||
-      blurTriggerKey.current === null
-    ) {
+    } else {
       handleValueChange(localValue);
     }
 

--- a/src/Timeline/NumberInput.tsx
+++ b/src/Timeline/NumberInput.tsx
@@ -51,9 +51,7 @@ export type NumberInputProps = {
     result: number;
   };
   config: NumberConfig;
-} & {
-  // TODO extract to a separate type
-  [key: `data-${string}`]: string | number | boolean | undefined;
+  "data-testid"?: string;
 };
 
 export function NumberInput({

--- a/src/Timeline/NumberInput.tsx
+++ b/src/Timeline/NumberInput.tsx
@@ -93,7 +93,8 @@ export function NumberInput({
         selectInputText();
       } else if (e.target.value === "") {
         // Empty target value means the current input is not a valid number
-        setLocalValue(configLatest.current.min.toString() ?? "0");
+        setLocalValue(configLatest.current.min.toString());
+        setHasError(false);
       } else {
         setLocalValue(e.target.value);
 

--- a/src/Timeline/PlayControls.spec.tsx
+++ b/src/Timeline/PlayControls.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { PropsWithChildren, useState } from "react";
 import { PlayControls } from "./PlayControls";
 import { TimeContext } from "./TimeContext";
+import { clickAndType } from "./test-util";
 
 describe("PlayControls requirements", () => {
   const TimelineProvider = ({
@@ -50,14 +51,12 @@ describe("PlayControls requirements", () => {
     expect(parseInt(currentInput.value, 10)).toBeGreaterThanOrEqual(0);
     expect(parseInt(currentInput.value, 10)).toBeLessThanOrEqual(durationTime);
 
-    await userEvent.clear(currentInput);
-    await userEvent.type(currentInput, "-50");
+    await clickAndType(currentInput, "-50");
     await userEvent.tab();
     expect(parseInt(currentInput.value, 10)).toBeGreaterThanOrEqual(0);
     expect(parseInt(currentInput.value, 10)).toBeLessThanOrEqual(durationTime);
 
-    await userEvent.clear(currentInput);
-    await userEvent.type(currentInput, "7000");
+    await clickAndType(currentInput, "7000");
     await userEvent.tab();
     expect(parseInt(currentInput.value, 10)).toBeGreaterThanOrEqual(0);
     expect(parseInt(currentInput.value, 10)).toBeLessThanOrEqual(durationTime);
@@ -77,9 +76,9 @@ describe("PlayControls requirements", () => {
       "duration-input"
     ) as HTMLInputElement;
 
-    await userEvent.clear(durationInput);
-    await userEvent.type(durationInput, "4000");
+    await clickAndType(durationInput, "4000");
     await userEvent.tab();
+    expect(parseInt(durationInput.value, 10)).toBe(4000);
     expect(parseInt(currentInput.value, 10)).toBe(4000);
   });
 
@@ -95,14 +94,13 @@ describe("PlayControls requirements", () => {
     expect(parseInt(durationInput.value, 10)).toBeGreaterThanOrEqual(100);
     expect(parseInt(durationInput.value, 10)).toBeLessThanOrEqual(6000);
 
-    await userEvent.clear(durationInput);
-    await userEvent.type(durationInput, "50");
+    await clickAndType(durationInput, "50");
     await userEvent.tab();
+    expect(parseInt(durationInput.value, 10)).toBe(100);
     expect(parseInt(durationInput.value, 10)).toBeGreaterThanOrEqual(100);
     expect(parseInt(durationInput.value, 10)).toBeLessThanOrEqual(6000);
 
-    await userEvent.clear(durationInput);
-    await userEvent.type(durationInput, "7000");
+    await clickAndType(durationInput, "7000");
     await userEvent.tab();
     expect(parseInt(durationInput.value, 10)).toBeGreaterThanOrEqual(100);
     expect(parseInt(durationInput.value, 10)).toBeLessThanOrEqual(6000);
@@ -122,8 +120,7 @@ describe("PlayControls requirements", () => {
     ) as HTMLInputElement;
 
     const fillThis = async (input: HTMLInputElement, value: string) => {
-      await userEvent.clear(input);
-      await userEvent.type(input, value);
+      await clickAndType(input, value);
       await userEvent.tab();
     };
 

--- a/src/Timeline/Timeline.tsx
+++ b/src/Timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { KeyframeListMemoed as KeyframeList } from "./KeyframeList";
 import { PlayControlsMemoed as PlayControls } from "./PlayControls";
 import { PlayheadMemoed as Playhead } from "./Playhead";

--- a/src/Timeline/test-util.ts
+++ b/src/Timeline/test-util.ts
@@ -1,0 +1,13 @@
+import userEvent from "@testing-library/user-event";
+
+export const clickAndType = async (input: HTMLInputElement, value: string) => {
+  await userEvent.click(input);
+
+  // Seems that even if handleFocus of NumberInput.tsx did called input.select(),
+  // it won't work in the test environment.
+  // Therefore, explicitly setting the selection range is needed.
+  await userEvent.type(input, value, {
+    initialSelectionStart: 0,
+    initialSelectionEnd: input.value.length,
+  });
+};


### PR DESCRIPTION
## Summary

The specification stated that the number input field would never be a negative number.

Therefore, it is meaningless to leave a single `-` in the field and wait for a user to enter e.g. 1 later. 

With this assumption, it is ok to just convert the field to be `0` if a user types `-`.

In a similar way, it is ok to do so if a user types e.g. "a" or "b".