### PR TITLE
Fix: clear the invalid status if arrow key or spinner changed the value

### DIFF
--- a/src/Timeline/NumberInput.spec.tsx
+++ b/src/Timeline/NumberInput.spec.tsx
@@ -464,6 +464,49 @@ describe("NumberInput requirements", () => {
       expect(input).not.toHaveAttribute("data-invalid");
     });
 
+    test("If an invalid number is corrected by spinner or arrow key, the invalid status should be removed", async () => {
+      const { getByRole } = render(
+        <NumberProvider initialValue={10}>
+          <NumberInputWrapper
+            validator={validatorSpy}
+            config={{
+              step: 10,
+              min: 0,
+              max: 300,
+            }}
+          />
+        </NumberProvider>
+      );
+      const input = getByRole("spinbutton") as HTMLInputElement;
+      expect(input.value).toBe("10");
+
+      async function initTheInput() {
+        await clickAndType(input, "123");
+        expect(input.value).toBe("123");
+        expect(input).toHaveAttribute("data-invalid");
+      }
+
+      await initTheInput();
+      clickSpinner(input, "increment", 123, 10);
+      expect(input.value).toBe("130");
+      expect(input).not.toHaveAttribute("data-invalid");
+
+      await initTheInput();
+      clickSpinner(input, "decrement", 123, 10);
+      expect(input.value).toBe("120");
+      expect(input).not.toHaveAttribute("data-invalid");
+
+      await initTheInput();
+      pressArrowKey(input, "ArrowUp", 123, 10);
+      expect(input.value).toBe("130");
+      expect(input).not.toHaveAttribute("data-invalid");
+
+      await initTheInput();
+      pressArrowKey(input, "ArrowDown", 123, 10);
+      expect(input.value).toBe("120");
+      expect(input).not.toHaveAttribute("data-invalid");
+    });
+
     test("If config changes, the validation result should reflect it accordingly", async () => {
       const config1 = {
         step: 1,

--- a/src/Timeline/NumberInput.tsx
+++ b/src/Timeline/NumberInput.tsx
@@ -72,14 +72,14 @@ export function NumberInput({
   const configLatest = useLatest(config);
   const onChangeLatest = useLatest(onChange);
 
-  const handleValueChange = useCallback((localValue: string) => {
-    const rawValue = parseFloat(localValue);
+  const confirmLocalValue = useCallback((localValue: string) => {
     const { result: validatedValue } = validator(
-      rawValue,
+      parseFloat(localValue),
       configLatest.current
     );
-    onChangeLatest.current(validatedValue);
     setLocalValue(validatedValue.toString());
+    setHasError(false);
+    onChangeLatest.current(validatedValue);
   }, []);
 
   const selectInputText = useCallback(() => {
@@ -89,7 +89,7 @@ export function NumberInput({
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (isSpinnerClicked.current || isArrowKeyDown.current) {
-        handleValueChange(e.target.value);
+        confirmLocalValue(e.target.value);
         selectInputText();
       } else if (e.target.value === "") {
         // Empty target value means the current input is not a valid number
@@ -105,7 +105,7 @@ export function NumberInput({
         setHasError(hasError);
       }
     },
-    [selectInputText, handleValueChange]
+    [selectInputText, confirmLocalValue]
   );
 
   const handleFocus = useCallback(() => {
@@ -118,7 +118,7 @@ export function NumberInput({
     if (blurTriggerKey.current === "Escape") {
       setLocalValue(valueString);
     } else {
-      handleValueChange(localValue);
+      confirmLocalValue(localValue);
     }
 
     setIsEditing(false);

--- a/src/Timeline/test-util.ts
+++ b/src/Timeline/test-util.ts
@@ -13,6 +13,22 @@ export const clickAndType = async (input: HTMLInputElement, value: string) => {
   });
 };
 
+function roundToNearestMultipleOfStep(
+  direction: "up" | "down",
+  currentValue: number,
+  step: number
+) {
+  let value = currentValue;
+  if (direction === "up") {
+    value = (Math.floor(currentValue / step) + 1) * step;
+  } else {
+    value =
+      Math.floor(currentValue / step) * step -
+      (currentValue % step === 0 ? step : 0);
+  }
+  return value;
+}
+
 // WORKAROUND: the correct behavior is not simulated by JSDOM
 export function pressArrowKey(
   input: HTMLElement,
@@ -20,9 +36,14 @@ export function pressArrowKey(
   currentValue: number,
   step: number
 ) {
-  const value = key === "ArrowUp" ? currentValue + step : currentValue - step;
+  const value = roundToNearestMultipleOfStep(
+    key === "ArrowUp" ? "up" : "down",
+    currentValue,
+    step
+  );
   fireEvent.keyDown(input, { key });
   fireEvent.change(input, { target: { value } });
+  fireEvent.keyUp(input, { key });
 }
 
 // WORKAROUND: the correct behavior is not simulated by JSDOM
@@ -32,8 +53,12 @@ export function clickSpinner(
   currentValue: number,
   step: number
 ) {
-  const value =
-    button === "increment" ? currentValue + step : currentValue - step;
+  const value = roundToNearestMultipleOfStep(
+    button === "increment" ? "up" : "down",
+    currentValue,
+    step
+  );
   fireEvent.mouseDown(spinner, { button: 0 });
   fireEvent.change(spinner, { target: { value } });
+  fireEvent.mouseUp(spinner, { button: 0 });
 }


### PR DESCRIPTION
## Summary

- Fix the bug.
- Rename "handleValueChange" to "confirmLocalValue" for clarity.
- Fix the implementation of "pressArrowKey" and "clickSpinner".